### PR TITLE
Added missing docutils requirement

### DIFF
--- a/libre/requirements/common.txt
+++ b/libre/requirements/common.txt
@@ -23,3 +23,4 @@ South==0.8.2
 suds==0.4
 
 xlrd==0.9.2
+docutils==0.11


### PR DESCRIPTION
I was getting a message from the admin pages urging me to install docutils.  Fixed by adding docutils as a requirement.
